### PR TITLE
Updated compiler to work with latest version of django-pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,30 @@ PIPELINE_COMPILERS = (
   'pipeline_typescript.compilers.TypescriptCompiler',
 )
 ```
+
+#### Using a local typescript install
+
+If you don't want to install the `typescript` dependency globally, you can install it within a specific project:
+
+	npm install --save-dev typescript
+
+Then, tell django-pipeline where the executable is:
+
+	# In settings.py
+	PIPELINE_TYPESCRIPT_BINARY = 'node_modules/.bin/tsc'
+
+#### The compiler is erroring out with "exit code 2"
+
+For some reason the most recent versions of `tsc` errors out with "exit code 2"
+
+	pipeline.exceptions.CompilerError: ['node_modules/.bin/tsc', '', '-out', '/some/django/dir/static/ts/main.js', '/some/django/dir/static/ts/main.ts'] exit code 2
+	b''
+
+Even more bizarre, the compiled Javascript file _is_ being output, so this doesn't necessarily indicate an issue with the TypeScript code itself...
+
+For some reason setting an argument (like `--diagnostics`) allows the `collectstatic` command to finish without issue:
+
+	# In settings.py
+	PIPELINE_TYPESCRIPT_ARGUMENTS = '--diagnostics'
+
+This appears to be related to [this Github issue](https://github.com/Microsoft/TypeScript/issues/8186) on the Microsoft/TypeScript repo.

--- a/pipeline_typescript/compilers.py
+++ b/pipeline_typescript/compilers.py
@@ -22,10 +22,11 @@ class TypescriptCompiler(SubProcessCompiler):
         return filename.endswith('.ts')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        # Redirect output because Typescript compiler outputs errors to stdout
-        command = "{command} {arguments} -out {outfile} {infile} 1>&2".format(
-            command=get_setting('PIPELINE_TYPESCRIPT_BINARY'),
-            arguments=get_setting('PIPELINE_TYPESCRIPT_ARGUMENTS'),
-            infile=infile,
-            outfile=outfile)
+        command = (
+            get_setting('PIPELINE_TYPESCRIPT_BINARY'),
+            get_setting('PIPELINE_TYPESCRIPT_ARGUMENTS'),
+            '-out',
+            outfile,
+            infile
+        )
         return self.execute_command(command)


### PR DESCRIPTION
I just updated this compiler to mirror pipeline's built-in compilers' `compile_file` method. Compiler commands are now expected to be a tuple comprised of argument strings. These effectively get `' '.join()`'d before getting executed.

I also included some additional instructions in the README file to show off this compiler's flexibility.
